### PR TITLE
商品削除機能#9 no2

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -35,6 +35,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item.destroy
+    redirect_to root_path 
+   end  
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :check_user, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -23,8 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    return if current_user.id == @item.user_id
-    redirect_to root_path
   end
 
   def update
@@ -38,7 +37,8 @@ class ItemsController < ApplicationController
   def destroy
     @item.destroy
     redirect_to root_path 
-   end  
+  end  
+
   private
 
   def item_params
@@ -48,5 +48,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def check_user
+      redirect_to root_path unless current_user.id == @item.user_id
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
   <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", root_path, method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete } , method: :delete, class:"item-destroy" %>
   <%end%>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
# What
商品削除機能の実装
# Why
商品削除機能の実装のため


・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
　https://i.gyazo.com/0b8a6734e71088b73af5db1060a24b85.mp4
※購入機能未実装のため、soldになっている商品が削除されています。